### PR TITLE
Spawn issues

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -207,6 +207,16 @@ command_specified (GPtrArray *child_argv,
   return FALSE;
 }
 
+static void
+session_bus_closed_cb (GDBusConnection *bus,
+                       gboolean remote_peer_vanished,
+                       GError *error,
+                       GMainLoop *loop)
+{
+  g_debug ("Session bus connection closed, quitting");
+  g_main_loop_quit (loop);
+}
+
 int
 main (int    argc,
       char **argv)
@@ -491,6 +501,9 @@ main (int    argc,
   forward_signals ();
 
   loop = g_main_loop_new (NULL, FALSE);
+
+  g_signal_connect (session_bus, "closed", G_CALLBACK (session_bus_closed_cb), loop);
+
   g_main_loop_run (loop);
 
   return 0;

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -142,7 +142,7 @@ forward_signal_idle_cb (gpointer user_data)
                                                       child_pid, sig, to_process_group),
                                        G_VARIANT_TYPE ("()"),
                                        G_DBUS_CALL_FLAGS_NONE,
-                                       0, NULL, &error);
+                                       -1, NULL, &error);
 
   if (error)
     g_debug ("Failed to forward signal: %s", error->message);

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -120,6 +120,7 @@ forward_signal_idle_cb (gpointer user_data)
   int sig = GPOINTER_TO_INT(user_data);
   g_autoptr(GVariant) reply = NULL;
   gboolean to_process_group = FALSE;
+  g_autoptr(GError) error = NULL;
 
   g_debug ("Forwarding signal: %d", sig);
 
@@ -141,7 +142,10 @@ forward_signal_idle_cb (gpointer user_data)
                                                       child_pid, sig, to_process_group),
                                        G_VARIANT_TYPE ("()"),
                                        G_DBUS_CALL_FLAGS_NONE,
-                                       0, NULL, NULL);
+                                       0, NULL, &error);
+
+  if (error)
+    g_debug ("Failed to forward signal: %s", error->message);
 
   if (sig == SIGSTOP)
     {


### PR DESCRIPTION
Three changes that make flatpak-spawn work as expected:
- Don't use a timeout of 0 in D-Bus calls, it doesn't work.
- Quit if we lose the session bus
- Add a --watch-bus option

Together, these fix the issues raised in #12 