### PR TITLE
Add g_autoptr backports, basic test coverage, and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# Copyright © 2015-2018 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+sudo: required
+dist: xenial
+language: c
+script:
+  - ./tests/ci-install.sh
+  - ci_parallel=2 ci_sudo=yes ./tests/ci-build.sh
+
+env:
+  # GLib 2.48
+  - ci_suite=xenial
+  # GLib 2.40. Not building the debug variant because the compiler is too
+  # old to support -fsanitize=address
+  - ci_docker=ubuntu:trusty ci_distro=ubuntu ci_suite=trusty ci_variant=production
+  # GLib 2.58
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=buster
+
+# vim:set sw=2 sts=2 et:

--- a/meson.build
+++ b/meson.build
@@ -9,12 +9,27 @@ project(
   meson_version: '>= 0.46.0',
 )
 
+bindir = join_paths(get_option('prefix'), get_option('bindir'))
+installed_tests_metadir = join_paths(get_option('prefix'),
+  get_option('datadir'),
+  'installed-tests',
+  meson.project_name())
+installed_tests_execdir = join_paths(get_option('prefix'),
+  get_option('libexecdir'),
+  'installed-tests',
+  meson.project_name())
+installed_tests_enabled = get_option('installed_tests')
+
 conf = configuration_data()
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+conf.set_quoted('BINDIR', bindir)
 conf.set('_GNU_SOURCE', 1)
 config_h = configure_file(output: 'config.h', configuration: conf)
 
 gio_unix = dependency('gio-unix-2.0')
 
+srcinc = include_directories('src')
+
 subdir('src')
+subdir('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('installed_tests',
+       type : 'boolean',
+       value : false,
+       description : 'enable installed tests')

--- a/src/backport-autoptr.h
+++ b/src/backport-autoptr.h
@@ -1,0 +1,243 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * GLIB - Library of useful routines for C programming
+ * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#ifdef G_OS_UNIX
+#include <gio/gunixfdlist.h>
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 43, 4)
+
+#define _GLIB_AUTOPTR_FUNC_NAME(TypeName) glib_autoptr_cleanup_##TypeName
+#define _GLIB_AUTOPTR_TYPENAME(TypeName)  TypeName##_autoptr
+#define _GLIB_AUTO_FUNC_NAME(TypeName)    glib_auto_cleanup_##TypeName
+#define _GLIB_CLEANUP(func)               __attribute__((cleanup(func)))
+#define _GLIB_DEFINE_AUTOPTR_CHAINUP(ModuleObjName, ParentName) \
+  typedef ModuleObjName *_GLIB_AUTOPTR_TYPENAME(ModuleObjName);                                          \
+  static inline void _GLIB_AUTOPTR_FUNC_NAME(ModuleObjName) (ModuleObjName **_ptr) {                     \
+    _GLIB_AUTOPTR_FUNC_NAME(ParentName) ((ParentName **) _ptr); }                                        \
+
+
+/* these macros are API */
+#define G_DEFINE_AUTOPTR_CLEANUP_FUNC(TypeName, func) \
+  typedef TypeName *_GLIB_AUTOPTR_TYPENAME(TypeName);                                                           \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTOPTR_FUNC_NAME(TypeName) (TypeName **_ptr) { if (*_ptr) (func) (*_ptr); }         \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(TypeName, func) \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTO_FUNC_NAME(TypeName) (TypeName *_ptr) { (func) (_ptr); }                         \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define G_DEFINE_AUTO_CLEANUP_FREE_FUNC(TypeName, func, none) \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTO_FUNC_NAME(TypeName) (TypeName *_ptr) { if (*_ptr != none) (func) (*_ptr); }     \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define g_autoptr(TypeName) _GLIB_CLEANUP(_GLIB_AUTOPTR_FUNC_NAME(TypeName)) _GLIB_AUTOPTR_TYPENAME(TypeName)
+#define g_auto(TypeName) _GLIB_CLEANUP(_GLIB_AUTO_FUNC_NAME(TypeName)) TypeName
+#define g_autofree _GLIB_CLEANUP(g_autoptr_cleanup_generic_gfree)
+
+/**
+ * g_steal_pointer:
+ * @pp: a pointer to a pointer
+ *
+ * Sets @pp to %NULL, returning the value that was there before.
+ *
+ * Conceptually, this transfers the ownership of the pointer from the
+ * referenced variable to the "caller" of the macro (ie: "steals" the
+ * reference).
+ *
+ * The return value will be properly typed, according to the type of
+ * @pp.
+ *
+ * This can be very useful when combined with g_autoptr() to prevent the
+ * return value of a function from being automatically freed.  Consider
+ * the following example (which only works on GCC and clang):
+ *
+ * |[
+ * GObject *
+ * create_object (void)
+ * {
+ *   g_autoptr(GObject) obj = g_object_new (G_TYPE_OBJECT, NULL);
+ *
+ *   if (early_error_case)
+ *     return NULL;
+ *
+ *   return g_steal_pointer (&obj);
+ * }
+ * ]|
+ *
+ * It can also be used in similar ways for 'out' parameters and is
+ * particularly useful for dealing with optional out parameters:
+ *
+ * |[
+ * gboolean
+ * get_object (GObject **obj_out)
+ * {
+ *   g_autoptr(GObject) obj = g_object_new (G_TYPE_OBJECT, NULL);
+ *
+ *   if (early_error_case)
+ *     return FALSE;
+ *
+ *   if (obj_out)
+ *     *obj_out = g_steal_pointer (&obj);
+ *
+ *   return TRUE;
+ * }
+ * ]|
+ *
+ * In the above example, the object will be automatically freed in the
+ * early error case and also in the case that %NULL was given for
+ * @obj_out.
+ *
+ * Since: 2.44
+ */
+static inline gpointer
+(g_steal_pointer) (gpointer pp)
+{
+  gpointer *ptr = (gpointer *) pp;
+  gpointer ref;
+
+  ref = *ptr;
+  *ptr = NULL;
+
+  return ref;
+}
+
+/* type safety */
+#define g_steal_pointer(pp) \
+  (0 ? (*(pp)) : (g_steal_pointer) (pp))
+
+static inline void
+g_autoptr_cleanup_generic_gfree (void *p)
+{
+  void **pp = (void**)p;
+  if (*pp)
+    g_free (*pp);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncQueue, g_async_queue_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GBookmarkFile, g_bookmark_file_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GBytes, g_bytes_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GChecksum, g_checksum_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDateTime, g_date_time_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDir, g_dir_close)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GError, g_error_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GHashTable, g_hash_table_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GHmac, g_hmac_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GIOChannel, g_io_channel_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GKeyFile, g_key_file_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GList, g_list_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GArray, g_array_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GPtrArray, g_ptr_array_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMainContext, g_main_context_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMainLoop, g_main_loop_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSource, g_source_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMappedFile, g_mapped_file_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMarkupParseContext, g_markup_parse_context_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(gchar, g_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GNode, g_node_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOptionContext, g_option_context_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOptionGroup, g_option_group_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GPatternSpec, g_pattern_spec_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GQueue, g_queue_free)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GQueue, g_queue_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRand, g_rand_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRegex, g_regex_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMatchInfo, g_match_info_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GScanner, g_scanner_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSequence, g_sequence_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSList, g_slist_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GStringChunk, g_string_chunk_free)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(GStrv, g_strfreev, NULL)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GThread, g_thread_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GMutex, g_mutex_clear)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GCond, g_cond_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTimer, g_timer_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTimeZone, g_time_zone_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTree, g_tree_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariant, g_variant_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantBuilder, g_variant_builder_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantBuilder, g_variant_builder_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantIter, g_variant_iter_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantDict, g_variant_dict_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantDict, g_variant_dict_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantType, g_variant_type_free)
+
+/* Add GObject-based types as needed. */
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncResult, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GCancellable, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GConverter, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GConverterOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDataInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFile, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileEnumerator, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileIOStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileInfo, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileMonitor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMemoryInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMemoryOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMount, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSocket, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSocketAddress, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocess, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocessLauncher, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTask, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsCertificate, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsDatabase, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsInteraction, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDBusConnection, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDBusMessage, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDBusMethodInvocation, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVolumeMonitor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GZlibCompressor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GZlibDecompressor, g_object_unref)
+
+#ifdef G_OS_UNIX
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUnixFDList, g_object_unref)
+#endif
+
+#endif /* !GLIB_CHECK_VERSION(2, 43, 3) */
+
+#if !GLIB_CHECK_VERSION(2, 45, 8)
+
+static inline void
+g_autoptr_cleanup_gstring_free (GString *string)
+{
+  if (string)
+    g_string_free (string, TRUE);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GString, g_autoptr_cleanup_gstring_free)
+
+#endif
+
+G_END_DECLS

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -26,6 +26,8 @@
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 
+#include "backport-autoptr.h"
+
 typedef enum {
   FLATPAK_SPAWN_FLAGS_CLEAR_ENV = 1 << 0,
   FLATPAK_SPAWN_FLAGS_LATEST_VERSION = 1 << 1,

--- a/tests/ci-Dockerfile.in
+++ b/tests/ci-Dockerfile.in
@@ -1,0 +1,10 @@
+FROM @ci_docker@
+ENV container docker
+
+ADD tests/ci-install.sh /ci-install.sh
+RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /ci-install.sh
+
+ADD . /home/user/ci
+RUN chown -R user:user /home/user/ci
+WORKDIR /home/user/ci
+USER user

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Copyright © 2015-2019 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+set -x
+
+NULL=
+
+# ci_distro:
+# OS distribution in which we are testing
+# Typical values: ubuntu, debian; maybe fedora in future
+: "${ci_distro:=ubuntu}"
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
+#
+# If empty, we test on "bare metal".
+# Typical values: ubuntu:xenial, debian:jessie-slim
+: "${ci_docker:=}"
+
+# ci_parallel:
+# A number of parallel jobs, passed to make -j
+: "${ci_parallel:=1}"
+
+# ci_sudo:
+# If yes, assume we can get root using sudo; if no, only use current user
+: "${ci_sudo:=no}"
+
+# ci_suite:
+# OS suite (release, branch) in which we are testing.
+# Typical values for ci_distro=debian: sid, jessie
+# Typical values for ci_distro=fedora might be 25, rawhide
+: "${ci_suite:=xenial}"
+
+# ci_test:
+# If yes, run tests; if no, just build
+: "${ci_test:=yes}"
+
+# ci_test_fatal:
+# If yes, test failures break the build; if no, they are reported but ignored
+: "${ci_test_fatal:=yes}"
+
+# ci_variant:
+# debug or production
+: "${ci_variant:=debug}"
+
+if [ -n "$ci_docker" ]; then
+    exec docker run \
+        --env=ci_docker="" \
+        --env=ci_parallel="${ci_parallel}" \
+        --env=ci_sudo=yes \
+        --env=ci_test="${ci_test}" \
+        --env=ci_test_fatal="${ci_test_fatal}" \
+        --env=ci_variant="${ci_variant}" \
+        --privileged \
+        ci-image \
+        tests/ci-build.sh
+fi
+
+maybe_fail_tests () {
+    if [ "$ci_test_fatal" = yes ]; then
+        exit 1
+    fi
+}
+
+# For pip
+export PATH="$HOME/.local/bin:$PATH"
+
+srcdir="$(pwd)"
+
+case "$ci_variant" in
+    (debug)
+        CFLAGS="-fsanitize=address -fsanitize=undefined -fPIE -pie"
+        export CFLAGS
+        # TODO: Fix the leaks and enable leak checking
+        ASAN_OPTIONS=detect_leaks=0
+        export ASAN_OPTIONS
+        ;;
+
+    (*)
+        ;;
+esac
+
+meson -Dinstalled_tests=true ci-build
+
+ninja -C ci-build
+[ "$ci_test" = no ] || meson test --verbose -C ci-build || maybe_fail_tests
+
+DESTDIR=$(pwd)/DESTDIR ninja -C ci-build install
+( cd DESTDIR && find . -ls )
+
+if [ "$ci_sudo" = yes ] && [ "$ci_test" = yes ]; then
+    sudo ninja -C ci-build install
+    gnome-desktop-testing-runner -d /usr/local/share flatpak-xdg-utils || \
+        maybe_fail_tests
+fi
+
+# vim:set sw=4 sts=4 et:

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Copyright © 2015-2019 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+set -x
+
+NULL=
+
+# ci_distro:
+# OS distribution in which we are testing
+# Typical values: ubuntu, debian; maybe fedora in future
+: "${ci_distro:=ubuntu}"
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
+: "${ci_docker:=}"
+
+# ci_in_docker:
+# Used internally by ci-install.sh. If yes, we are inside the Docker image
+# (ci_docker is empty in this case).
+: "${ci_in_docker:=no}"
+
+# ci_suite:
+# OS suite (release, branch) in which we are testing.
+# Typical values for ci_distro=debian: sid, jessie
+# Typical values for ci_distro=fedora might be 25, rawhide
+: "${ci_suite:=xenial}"
+
+if [ $(id -u) = 0 ]; then
+    sudo=
+else
+    sudo=sudo
+fi
+
+if [ -n "$ci_docker" ]; then
+    sed \
+        -e "s/@ci_distro@/${ci_distro}/" \
+        -e "s/@ci_docker@/${ci_docker}/" \
+        -e "s/@ci_suite@/${ci_suite}/" \
+        < tests/ci-Dockerfile.in > Dockerfile
+    exec docker build -t ci-image .
+fi
+
+case "$ci_distro" in
+    (debian|ubuntu)
+        # Don't ask questions, just do it
+        sudo="$sudo env DEBIAN_FRONTEND=noninteractive"
+
+        $sudo apt-get -qq -y update
+        $sudo apt-get -qq -y --no-install-recommends install \
+            build-essential \
+            dbus \
+            gnome-desktop-testing \
+            libglib2.0-dev \
+            ninja-build \
+            python3 \
+            python3-pip \
+            python3-setuptools \
+            sudo \
+            unzip \
+            wget \
+            ${NULL}
+
+        if [ "$ci_in_docker" = yes ]; then
+            # Add the user that we will use to do the build inside the
+            # Docker container, and let them use sudo
+            adduser --disabled-password --gecos "" user
+            echo "user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
+            chmod 0440 /etc/sudoers.d/nopasswd
+        fi
+
+        case "$ci_suite" in
+            (trusty)
+                wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
+                $sudo unzip ninja-linux.zip -d /usr/local/bin
+                $sudo apt-get -qq -y --no-install-recommends install \
+                    python3.5
+                $sudo python3.5 /usr/bin/pip3 install meson
+                ;;
+            (xenial|bionic)
+                $sudo pip3 install meson
+                ;;
+            (stretch)
+                $sudo apt-get -qq -y --no-install-recommends \
+                    -t ${ci_suite}-backports install \
+                    meson
+                ;;
+            (*)
+                $sudo apt-get -qq -y --no-install-recommends install \
+                    meson
+                ;;
+        esac
+        ;;
+
+    (*)
+        echo "Don't know how to set up ${ci_distro}" >&2
+        exit 1
+        ;;
+esac
+
+# vim:set sw=4 sts=4 et:

--- a/tests/common.c
+++ b/tests/common.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2018-2019 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common.h"
+
+#include <string.h>
+
+#include <gio/gio.h>
+
+#include "backport-autoptr.h"
+
+void
+setup_dbus_daemon (GSubprocess **dbus_daemon,
+                   gchar       **dbus_address)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  GInputStream *address_pipe;
+  gchar address_buffer[4096] = { 0 };
+  g_autofree gchar *escaped = NULL;
+  char *newline;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  *dbus_daemon = g_subprocess_launcher_spawn (launcher, &error,
+                                              "dbus-daemon",
+                                              "--session",
+                                              "--print-address=1",
+                                              "--nofork",
+                                              NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (*dbus_daemon);
+
+  address_pipe = g_subprocess_get_stdout_pipe (*dbus_daemon);
+
+  /* Crash if it takes too long to get the address */
+  alarm (30);
+
+  while (strchr (address_buffer, '\n') == NULL)
+    {
+      if (strlen (address_buffer) >= sizeof (address_buffer) - 1)
+        g_error ("Read %" G_GSIZE_FORMAT " bytes from dbus-daemon with "
+                 "no newline",
+                 sizeof (address_buffer) - 1);
+
+      g_input_stream_read (address_pipe,
+                           address_buffer + strlen (address_buffer),
+                           sizeof (address_buffer) - strlen (address_buffer),
+                           NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  /* Disable alarm */
+  alarm (0);
+
+  newline = strchr (address_buffer, '\n');
+  g_assert_nonnull (newline);
+  *newline = '\0';
+  *dbus_address = g_strdup (address_buffer);
+}
+
+void
+own_name_sync (GDBusConnection *conn,
+               const char *name)
+{
+  g_autoptr(GVariant) variant = NULL;
+  g_autoptr(GError) error = NULL;
+  guint32 result;
+
+  /* We don't use g_bus_own_name() here because it's easier to be
+   * synchronous */
+  variant = g_dbus_connection_call_sync (conn,
+                                         DBUS_SERVICE_DBUS,
+                                         DBUS_PATH_DBUS,
+                                         DBUS_IFACE_DBUS,
+                                         "RequestName",
+                                         g_variant_new ("(su)",
+                                                        name,
+                                                        DBUS_NAME_FLAG_DO_NOT_QUEUE),
+                                         G_VARIANT_TYPE ("(u)"),
+                                         G_DBUS_CALL_FLAGS_NONE, -1,
+                                         NULL, &error);
+  g_assert_no_error (error);
+  g_variant_get (variant, "(u)", &result);
+  g_assert_cmpuint (result, ==, DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER);
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2018-2019 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+/* GDBus interface info contains padding for future expansion, silence
+ * warnings about this */
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#define DBUS_SERVICE_DBUS "org.freedesktop.DBus"
+#define DBUS_PATH_DBUS "/org/freedesktop/DBus"
+#define DBUS_IFACE_DBUS DBUS_SERVICE_DBUS
+#define DBUS_NAME_FLAG_DO_NOT_QUEUE 4
+#define DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER 1
+
+void setup_dbus_daemon (GSubprocess **dbus_daemon,
+                        gchar       **dbus_address);
+void own_name_sync (GDBusConnection *conn,
+                    const char *name);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,44 @@
+test_env = environment()
+test_env.set('G_DEBUG', 'gc-friendly')
+test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
+test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+test_env.set('GIO_USE_VFS', 'local')
+test_env.set('XDG_EMAIL', xdg_email.full_path())
+test_env.set('XDG_OPEN', xdg_open.full_path())
+test_env.set('MALLOC_CHECK_', '2')
+
+tests = [
+  'test-email',
+  'test-open',
+]
+
+test_timeout = 60
+
+installed_tests_template_tap = files('template-tap.test.in')
+
+foreach test_name : tests
+  template = installed_tests_template_tap
+
+  if installed_tests_enabled
+    test_conf = configuration_data()
+    test_conf.set('installed_tests_dir', installed_tests_execdir)
+    test_conf.set('program', test_name)
+    configure_file(
+      input: template,
+      output: test_name + '.test',
+      install_dir: installed_tests_metadir,
+      configuration: test_conf
+    )
+  endif
+
+  exe = executable(test_name, [test_name + '.c', 'common.c', 'common.h'],
+    c_args: ['-include', '@0@'.format(config_h)],
+    dependencies: [gio_unix],
+    include_directories : [srcinc],
+    install_dir: installed_tests_execdir,
+    install: installed_tests_enabled,
+  )
+
+  test(test_name, exe, env : test_env, timeout : test_timeout,
+    suite : ['flatpak-xdg-utils'], args : ['--tap'])
+endforeach

--- a/tests/template-tap.test.in
+++ b/tests/template-tap.test.in
@@ -1,0 +1,4 @@
+[Test]
+Type=session
+Exec=@installed_tests_dir@/@program@ --tap
+Output=TAP

--- a/tests/test-email.c
+++ b/tests/test-email.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright © 2018-2019 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "backport-autoptr.h"
+#include "common.h"
+
+#define PORTAL_BUS_NAME "org.freedesktop.portal.Desktop"
+#define PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
+#define PORTAL_IFACE_NAME "org.freedesktop.portal.Email"
+
+typedef struct
+{
+  GSubprocess *dbus_daemon;
+  gchar *dbus_address;
+  GSubprocess *xdg_email;
+  gchar *xdg_email_path;
+  GDBusConnection *mock_conn;
+  guint mock_object;
+  GQueue invocations;
+} Fixture;
+
+typedef struct
+{
+  int dummy;
+} Config;
+
+static void
+mock_method_call (GDBusConnection *conn G_GNUC_UNUSED,
+                  const gchar *sender G_GNUC_UNUSED,
+                  const gchar *object_path G_GNUC_UNUSED,
+                  const gchar *interface_name,
+                  const gchar *method_name,
+                  GVariant *parameters G_GNUC_UNUSED,
+                  GDBusMethodInvocation *invocation,
+                  gpointer user_data)
+{
+  Fixture *f = user_data;
+  g_autofree gchar *params = NULL;
+
+  params = g_variant_print (parameters, TRUE);
+
+  g_test_message ("Method called: %s.%s%s", interface_name, method_name,
+                  params);
+
+  g_queue_push_tail (&f->invocations, g_object_ref (invocation));
+  g_dbus_method_invocation_return_value (invocation,
+                                         g_variant_new ("(o)", "/foo"));
+}
+
+static GDBusArgInfo arg_parent_window =
+{
+  -1,
+  "parent_window",
+  "s",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_options =
+{
+  -1,
+  "options",
+  "a{sv}",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_out_handle =
+{
+  -1,
+  "handle",
+  "o",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo *in_args[] =
+{
+  &arg_parent_window,
+  &arg_options,
+  NULL
+};
+
+static GDBusArgInfo *out_args[] =
+{
+  &arg_out_handle,
+  NULL
+};
+
+static GDBusMethodInfo compose_email_info =
+{
+  -1,
+  "ComposeEmail",
+  in_args,
+  out_args,
+  NULL  /* annotations */
+};
+
+static GDBusMethodInfo *method_info[] =
+{
+  &compose_email_info,
+  NULL
+};
+
+static GDBusInterfaceInfo iface_info =
+{
+  -1,
+  PORTAL_IFACE_NAME,
+  method_info,
+  NULL, /* signals */
+  NULL, /* properties */
+  NULL  /* annotations */
+};
+
+static const GDBusInterfaceVTable vtable =
+{
+  mock_method_call,
+  NULL, /* get */
+  NULL  /* set */
+};
+
+static void
+setup (Fixture *f,
+       gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_queue_init (&f->invocations);
+
+  setup_dbus_daemon (&f->dbus_daemon, &f->dbus_address);
+
+  f->xdg_email_path = g_strdup (g_getenv ("XDG_EMAIL"));
+
+  if (f->xdg_email_path == NULL)
+    f->xdg_email_path = g_strdup (BINDIR "/xdg-email");
+
+  f->mock_conn = g_dbus_connection_new_for_address_sync (f->dbus_address,
+                                                         (G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+                                                          G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+                                                         NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->mock_conn);
+
+  f->mock_object = g_dbus_connection_register_object (f->mock_conn,
+                                                      PORTAL_OBJECT_PATH,
+                                                      &iface_info,
+                                                      &vtable,
+                                                      f,
+                                                      NULL,
+                                                      &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (f->mock_object, !=, 0);
+
+  own_name_sync (f->mock_conn, PORTAL_BUS_NAME);
+}
+
+static void
+test_help (Fixture *f,
+           gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autofree gchar *stdout_buf;
+  g_autofree gchar *stderr_buf;
+  g_autoptr(GError) error = NULL;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+                                        G_SUBPROCESS_FLAGS_STDERR_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_email = g_subprocess_launcher_spawn (launcher, &error,
+                                              f->xdg_email_path,
+                                              "--help",
+                                              NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_email);
+
+  g_subprocess_communicate_utf8 (f->xdg_email, NULL, NULL, &stdout_buf,
+                                 &stderr_buf, &error);
+  g_assert_cmpstr (stderr_buf, ==, "");
+  g_assert_nonnull (stdout_buf);
+  g_test_message ("xdg-open --help: %s", stdout_buf);
+  g_assert_true (strstr (stdout_buf, "--version") != NULL);
+
+  g_subprocess_wait_check (f->xdg_email, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+test_minimal (Fixture *f,
+              gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation = NULL;
+  g_autoptr(GVariant) asv = NULL;
+  g_autoptr(GVariantDict) dict = NULL;
+  GVariant *parameters;
+  const gchar *window;
+  const gchar *address;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_email = g_subprocess_launcher_spawn (launcher, &error,
+                                             f->xdg_email_path,
+                                             "me@example.com",
+                                             NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_email);
+
+  while (g_queue_get_length (&f->invocations) < 1)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_subprocess_wait_check (f->xdg_email, NULL, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (g_queue_get_length (&f->invocations), ==, 1);
+  invocation = g_queue_pop_head (&f->invocations);
+
+  g_assert_cmpstr (g_dbus_method_invocation_get_interface_name (invocation),
+                   ==, PORTAL_IFACE_NAME);
+  g_assert_cmpstr (g_dbus_method_invocation_get_method_name (invocation),
+                   ==, "ComposeEmail");
+
+  parameters = g_dbus_method_invocation_get_parameters (invocation);
+  g_assert_cmpstr (g_variant_get_type_string (parameters), ==, "(sa{sv})");
+  g_variant_get (parameters, "(&s@a{sv})",
+                 &window, &asv);
+  g_assert_cmpstr (window, ==, "");
+
+  dict = g_variant_dict_new (asv);
+  g_assert_true (g_variant_dict_lookup (dict, "address", "&s", &address));
+  g_assert_cmpstr (address, ==, "me@example.com");
+  g_assert_false (g_variant_dict_contains (dict, "subject"));
+  g_assert_false (g_variant_dict_contains (dict, "body"));
+  g_assert_false (g_variant_dict_contains (dict, "attachments"));
+}
+
+static void
+test_maximal (Fixture *f,
+              gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation = NULL;
+  g_autoptr(GVariant) asv = NULL;
+  g_autoptr(GVariantDict) dict = NULL;
+  g_autoptr(GVariant) attachments = NULL;
+  GVariant *parameters;
+  const gchar *window;
+  const gchar *address;
+  const gchar *subject;
+  const gchar *body;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_email = g_subprocess_launcher_spawn (launcher, &error,
+                                             f->xdg_email_path,
+                                             "--subject", "Make Money Fast",
+                                             "--body", "Your spam here",
+                                             "--attach", "/dev/null",
+                                             "me@example.com",
+                                             NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_email);
+
+  while (g_queue_get_length (&f->invocations) < 1)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_subprocess_wait_check (f->xdg_email, NULL, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (g_queue_get_length (&f->invocations), ==, 1);
+  invocation = g_queue_pop_head (&f->invocations);
+
+  g_assert_cmpstr (g_dbus_method_invocation_get_interface_name (invocation),
+                   ==, PORTAL_IFACE_NAME);
+  g_assert_cmpstr (g_dbus_method_invocation_get_method_name (invocation),
+                   ==, "ComposeEmail");
+
+  parameters = g_dbus_method_invocation_get_parameters (invocation);
+  g_assert_cmpstr (g_variant_get_type_string (parameters), ==, "(sa{sv})");
+  g_variant_get (parameters, "(&s@a{sv})",
+                 &window, &asv);
+  g_assert_cmpstr (window, ==, "");
+
+  dict = g_variant_dict_new (asv);
+  g_assert_true (g_variant_dict_lookup (dict, "address", "&s", &address));
+  g_assert_cmpstr (address, ==, "me@example.com");
+  g_assert_true (g_variant_dict_lookup (dict, "subject", "&s", &subject));
+  g_assert_cmpstr (subject, ==, "Make Money Fast");
+  g_assert_true (g_variant_dict_lookup (dict, "body", "&s", &body));
+  g_assert_cmpstr (body, ==, "Your spam here");
+  /* TODO: Also test that the attachment went through correctly (this
+   * doesn't seem to work at the moment) */
+}
+
+static void
+teardown (Fixture *f,
+          gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  gpointer free_me;
+
+  for (free_me = g_queue_pop_head (&f->invocations);
+       free_me != NULL;
+       free_me = g_queue_pop_head (&f->invocations))
+    g_object_unref (free_me);
+
+  if (f->mock_object != 0)
+    g_dbus_connection_unregister_object (f->mock_conn, f->mock_object);
+
+  if (f->dbus_daemon != NULL)
+    {
+      g_subprocess_send_signal (f->dbus_daemon, SIGTERM);
+      g_subprocess_wait (f->dbus_daemon, NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  g_clear_object (&f->dbus_daemon);
+  g_clear_object (&f->xdg_email);
+  g_clear_object (&f->mock_conn);
+  g_free (f->dbus_address);
+  g_free (f->xdg_email_path);
+  alarm (0);
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/help", Fixture, NULL, setup, test_help, teardown);
+  g_test_add ("/minimal", Fixture, NULL, setup, test_minimal, teardown);
+  g_test_add ("/maximal", Fixture, NULL, setup, test_maximal, teardown);
+
+  return g_test_run ();
+}

--- a/tests/test-open.c
+++ b/tests/test-open.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright © 2018-2019 Collabora Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <gio/gunixfdlist.h>
+
+#include "backport-autoptr.h"
+#include "common.h"
+
+#define PORTAL_BUS_NAME "org.freedesktop.portal.Desktop"
+#define PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
+#define PORTAL_IFACE_NAME "org.freedesktop.portal.OpenURI"
+
+typedef struct
+{
+  GSubprocess *dbus_daemon;
+  gchar *dbus_address;
+  GSubprocess *xdg_open;
+  gchar *xdg_open_path;
+  GDBusConnection *mock_conn;
+  guint mock_object;
+  GQueue invocations;
+} Fixture;
+
+typedef struct
+{
+  int dummy;
+} Config;
+
+static void
+mock_method_call (GDBusConnection *conn G_GNUC_UNUSED,
+                  const gchar *sender G_GNUC_UNUSED,
+                  const gchar *object_path G_GNUC_UNUSED,
+                  const gchar *interface_name,
+                  const gchar *method_name,
+                  GVariant *parameters G_GNUC_UNUSED,
+                  GDBusMethodInvocation *invocation,
+                  gpointer user_data)
+{
+  Fixture *f = user_data;
+  g_autofree gchar *params = NULL;
+
+  params = g_variant_print (parameters, TRUE);
+
+  g_test_message ("Method called: %s.%s%s", interface_name, method_name,
+                  params);
+
+  g_queue_push_tail (&f->invocations, g_object_ref (invocation));
+  g_dbus_method_invocation_return_value (invocation,
+                                         g_variant_new ("(o)", "/foo"));
+}
+
+static GDBusArgInfo arg_parent_window =
+{
+  -1,
+  "parent_window",
+  "s",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_uri =
+{
+  -1,
+  "uri",
+  "s",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_options =
+{
+  -1,
+  "options",
+  "a{sv}",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_fd =
+{
+  -1,
+  "fd",
+  "h",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo arg_out_handle =
+{
+  -1,
+  "handle",
+  "o",
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo *open_uri_in_args[] =
+{
+  &arg_parent_window,
+  &arg_uri,
+  &arg_options,
+  NULL
+};
+
+static GDBusArgInfo *open_uri_out_args[] =
+{
+  &arg_out_handle,
+  NULL
+};
+
+static GDBusMethodInfo open_uri_info =
+{
+  -1,
+  "OpenURI",
+  open_uri_in_args,
+  open_uri_out_args,
+  NULL  /* annotations */
+};
+
+static GDBusArgInfo *open_file_in_args[] =
+{
+  &arg_parent_window,
+  &arg_fd,
+  &arg_options,
+  NULL
+};
+
+static GDBusMethodInfo open_file_info =
+{
+  -1,
+  "OpenFile",
+  open_file_in_args,
+  open_uri_out_args,   /* the same */
+  NULL  /* annotations */
+};
+
+static GDBusMethodInfo *method_info[] =
+{
+  &open_uri_info,
+  &open_file_info,
+  NULL
+};
+
+static GDBusInterfaceInfo iface_info =
+{
+  -1,
+  PORTAL_IFACE_NAME,
+  method_info,
+  NULL, /* signals */
+  NULL, /* properties */
+  NULL  /* annotations */
+};
+
+static const GDBusInterfaceVTable vtable =
+{
+  mock_method_call,
+  NULL, /* get */
+  NULL  /* set */
+};
+
+static void
+setup (Fixture *f,
+       gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_queue_init (&f->invocations);
+
+  setup_dbus_daemon (&f->dbus_daemon, &f->dbus_address);
+
+  f->xdg_open_path = g_strdup (g_getenv ("XDG_OPEN"));
+
+  if (f->xdg_open_path == NULL)
+    f->xdg_open_path = g_strdup (BINDIR "/xdg-open");
+
+  f->mock_conn = g_dbus_connection_new_for_address_sync (f->dbus_address,
+                                                         (G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+                                                          G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+                                                         NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->mock_conn);
+
+  f->mock_object = g_dbus_connection_register_object (f->mock_conn,
+                                                      PORTAL_OBJECT_PATH,
+                                                      &iface_info,
+                                                      &vtable,
+                                                      f,
+                                                      NULL,
+                                                      &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (f->mock_object, !=, 0);
+
+  own_name_sync (f->mock_conn, PORTAL_BUS_NAME);
+}
+
+static void
+test_help (Fixture *f,
+           gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autofree gchar *stdout_buf;
+  g_autofree gchar *stderr_buf;
+  g_autoptr(GError) error = NULL;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+                                        G_SUBPROCESS_FLAGS_STDERR_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_open = g_subprocess_launcher_spawn (launcher, &error,
+                                             f->xdg_open_path,
+                                             "--help",
+                                             NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_open);
+
+  g_subprocess_communicate_utf8 (f->xdg_open, NULL, NULL, &stdout_buf,
+                                 &stderr_buf, &error);
+  g_assert_cmpstr (stderr_buf, ==, "");
+  g_assert_nonnull (stdout_buf);
+  g_test_message ("xdg-open --help: %s", stdout_buf);
+  g_assert_true (strstr (stdout_buf, "--version") != NULL);
+
+  g_subprocess_wait_check (f->xdg_open, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+test_uri (Fixture *f,
+          gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation = NULL;
+  GVariant *parameters;
+  const gchar *window;
+  const gchar *uri;
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_open = g_subprocess_launcher_spawn (launcher, &error,
+                                             f->xdg_open_path,
+                                             "http://example.com/",
+                                             NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_open);
+
+  while (g_queue_get_length (&f->invocations) < 1)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_subprocess_wait_check (f->xdg_open, NULL, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (g_queue_get_length (&f->invocations), ==, 1);
+  invocation = g_queue_pop_head (&f->invocations);
+
+  g_assert_cmpstr (g_dbus_method_invocation_get_interface_name (invocation),
+                   ==, PORTAL_IFACE_NAME);
+  g_assert_cmpstr (g_dbus_method_invocation_get_method_name (invocation),
+                   ==, "OpenURI");
+
+  parameters = g_dbus_method_invocation_get_parameters (invocation);
+  g_assert_cmpstr (g_variant_get_type_string (parameters), ==, "(ssa{sv})");
+  g_variant_get (parameters, "(&s&sa{sv})",
+                 &window, &uri, NULL);
+  g_assert_cmpstr (window, ==, "");
+  g_assert_cmpstr (uri, ==, "http://example.com/");
+}
+
+static void
+test_file (Fixture *f,
+           gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GSubprocessLauncher) launcher = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation = NULL;
+  GVariant *parameters;
+  const gchar *window;
+  gint32 handle;
+  GDBusMessage *message;
+  GUnixFDList *fd_list;
+  const int *fds;
+  struct stat ours, theirs;
+
+  if (stat ("/dev/null", &ours) < 0)
+    g_error ("stat(/dev/null): %s", g_strerror (errno));
+
+  launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDOUT_PIPE);
+  g_subprocess_launcher_setenv (launcher,
+                                "DBUS_SESSION_BUS_ADDRESS",
+                                f->dbus_address,
+                                TRUE);
+
+  f->xdg_open = g_subprocess_launcher_spawn (launcher, &error,
+                                             f->xdg_open_path,
+                                             "/dev/null",
+                                             NULL);
+  g_assert_no_error (error);
+  g_assert_nonnull (f->xdg_open);
+
+  while (g_queue_get_length (&f->invocations) < 1)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_subprocess_wait_check (f->xdg_open, NULL, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpuint (g_queue_get_length (&f->invocations), ==, 1);
+  invocation = g_queue_pop_head (&f->invocations);
+
+  g_assert_cmpstr (g_dbus_method_invocation_get_interface_name (invocation),
+                   ==, PORTAL_IFACE_NAME);
+  g_assert_cmpstr (g_dbus_method_invocation_get_method_name (invocation),
+                   ==, "OpenFile");
+
+  parameters = g_dbus_method_invocation_get_parameters (invocation);
+  g_assert_cmpstr (g_variant_get_type_string (parameters), ==, "(sha{sv})");
+  g_variant_get (parameters, "(&sha{sv})",
+                 &window, &handle, NULL);
+  g_assert_cmpstr (window, ==, "");
+  g_assert_cmpint (handle, ==, 0);
+
+  message = g_dbus_method_invocation_get_message (invocation);
+  g_assert_cmpuint (g_dbus_message_get_num_unix_fds (message), ==, 1);
+  fd_list = g_dbus_message_get_unix_fd_list (message);
+  fds = g_unix_fd_list_peek_fds (fd_list, NULL);
+  g_assert_cmpint (fds[0], >=, 0);
+  g_assert_cmpint (fds[1], ==, -1);
+
+  if (fstat (fds[0], &theirs) < 0)
+    g_error ("stat(their fd): %s", g_strerror (errno));
+
+  /* It's really /dev/null */
+  g_assert_cmpuint (ours.st_dev, ==, theirs.st_dev);
+  g_assert_cmpuint (ours.st_ino, ==, theirs.st_ino);
+}
+
+static void
+teardown (Fixture *f,
+          gconstpointer context G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  gpointer free_me;
+
+  for (free_me = g_queue_pop_head (&f->invocations);
+       free_me != NULL;
+       free_me = g_queue_pop_head (&f->invocations))
+    g_object_unref (free_me);
+
+  if (f->mock_object != 0)
+    g_dbus_connection_unregister_object (f->mock_conn, f->mock_object);
+
+  if (f->dbus_daemon != NULL)
+    {
+      g_subprocess_send_signal (f->dbus_daemon, SIGTERM);
+      g_subprocess_wait (f->dbus_daemon, NULL, &error);
+      g_assert_no_error (error);
+    }
+
+  g_clear_object (&f->dbus_daemon);
+  g_clear_object (&f->xdg_open);
+  g_clear_object (&f->mock_conn);
+  g_free (f->dbus_address);
+  g_free (f->xdg_open_path);
+  alarm (0);
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add ("/help", Fixture, NULL, setup, test_help, teardown);
+  g_test_add ("/uri", Fixture, NULL, setup, test_uri, teardown);
+  g_test_add ("/file", Fixture, NULL, setup, test_file, teardown);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
I'm looking into adding flatpak-xdg-utils to Debian, so that we can build containers from Debian packages and have them talk to xdg-desktop-portal on the host system. For boring administrative reasons it's easier to add as-installed tests in the first upload of a new Debian package than to upload it without tests and add them later, so here's some basic test coverage.

This doesn't cover anything particularly fancy yet, and also doesn't yet cover flatpak-spawn at all, but it's a good starting point for not regressing.

I'm not sure how backwards-compatible these tools are meant to be, but it seems to be straightforward to make them work on Ubuntu 14.04 LTS (GLib 2.40), so I've added the necessary g_autoptr glue to let people backport the package to Ubuntu 14.04, Debian 9 or contemporary distributions and build containers from those if they want to. These backports resemble the ones in xdg-dbus-proxy, with the addition of GUnixFDList and GDBusMessageInvocation.

I've also added Travis-CI integration, very similar to what's in xdg-dbus-proxy, which in turn is based on dbus. The scripts in tests/ are reasonably CI-system-agnostic and should be feasible to hook up to Gitlab-CI or similar if desired (as has been done in dbus). It should also be reasonably straightforward to build in a non-Debian-derived container by adding an alternative code path alongside the various apt-get calls.

If the baseline distribution is meant to be older or newer than Ubuntu 14.04 LTS, we can adjust the suites used: Debian releases and Ubuntu LTS releases are about a year apart, so we can easily hit about 50% of possible GLib branches.