### PR TITLE
xdg-email, xdg-open: Terminate GOptionEntry array correctly

### DIFF
--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -64,7 +64,8 @@ static GOptionEntry entries[] = {
   { "manual", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &show_help, NULL, NULL },
   { "version", 0, 0, G_OPTION_ARG_NONE, &show_version, N_("Show program version"), NULL },
 
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uris, NULL, NULL }
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uris, NULL, NULL },
+  { NULL, 0, 0, 0, NULL, NULL, NULL }
 };
 
 static gboolean

--- a/src/xdg-open.c
+++ b/src/xdg-open.c
@@ -39,7 +39,8 @@ static GOptionEntry entries[] = {
   { "manual", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &show_help, NULL, NULL },
   { "version", 0, 0, G_OPTION_ARG_NONE, &show_version, N_("Show program version"), NULL },
 
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uris, NULL, NULL }
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uris, NULL, NULL },
+  { NULL, 0, 0, 0, NULL, NULL, NULL }
 };
 
 int


### PR DESCRIPTION
g_option_context_add_main_entries() is documented to take an array of
GOptionEntry, terminated by a NULL-filled entry; however, these tools
did not terminate the array.

In practice it appears that current toolchains place enough zero bytes
after the array that this worked as intended on most architectures, but
this is not the case on the Debian mips64el and riscv64 ports.