### PR TITLE
Fix test failures caused by Email v3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,15 @@
 # SOFTWARE.
 
 sudo: required
-dist: xenial
+dist: bionic
 language: c
 script:
   - ./tests/ci-install.sh
   - ci_parallel=2 ci_sudo=yes ./tests/ci-build.sh
 
 env:
-  # GLib 2.48
-  - ci_suite=xenial
+  # GLib 2.56
+  - ci_suite=bionic
   # GLib 2.40. Not building the debug variant because the compiler is too
   # old to support -fsanitize=address
   - ci_docker=ubuntu:trusty ci_distro=ubuntu ci_suite=trusty ci_variant=production

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
   license: 'LGPL-2.1+',
   default_options: [
     'buildtype=debugoptimized',
+    'c_std=gnu99',
     'warning_level=2',
   ],
   meson_version: '>= 0.46.0',

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -27,6 +27,8 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "backport-autoptr.h"
+
 #define PORTAL_BUS_NAME    "org.freedesktop.portal.Desktop"
 #define PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
 #define PORTAL_IFACE_NAME  "org.freedesktop.portal.Email"

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -75,7 +75,7 @@ main (int argc, char *argv[])
   GUnixFDList *fd_list = NULL;
   g_autoptr(GVariant) ret = NULL;
   g_autoptr(GVariant) v = NULL;
-  guint version;
+  guint version = 0;
 
   context = g_option_context_new ("[ mailto-uri | address(es) ]");
 
@@ -132,8 +132,16 @@ main (int argc, char *argv[])
                                      G_MAXINT,
                                      NULL,
                                      NULL);
-  g_variant_get (ret, "(v)", &v);
-  g_variant_get (v, "u", &version);
+  if (ret != NULL)
+    {
+      g_variant_get (ret, "(v)", &v);
+
+      if (g_variant_is_of_type (v, G_VARIANT_TYPE ("u")))
+        g_variant_get (v, "u", &version);
+      else
+        g_warning ("o.fd.portal.Email.version had unexpected type %s",
+                   g_variant_get_type_string (v));
+    }
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -75,7 +75,7 @@ main (int argc, char *argv[])
   GUnixFDList *fd_list = NULL;
   g_autoptr(GVariant) ret = NULL;
   g_autoptr(GVariant) v = NULL;
-  guint version = 0;
+  guint32 version = 0;
 
   context = g_option_context_new ("[ mailto-uri | address(es) ]");
 

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -93,9 +93,14 @@ case "$ci_distro" in
         fi
 
         case "$ci_suite" in
-            (trusty)
+            (trusty|xenial)
                 wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
                 $sudo unzip ninja-linux.zip -d /usr/local/bin
+                ;;
+        esac
+
+        case "$ci_suite" in
+            (trusty)
                 $sudo apt-get -qq -y --no-install-recommends install \
                     python3.5
                 $sudo python3.5 /usr/bin/pip3 install meson

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,5 @@
 test_env = environment()
-test_env.set('G_DEBUG', 'gc-friendly')
+test_env.set('G_DEBUG', 'gc-friendly,fatal-criticals')
 test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
 test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
 test_env.set('GIO_USE_VFS', 'local')

--- a/tests/test-email.c
+++ b/tests/test-email.c
@@ -379,7 +379,12 @@ test_maximal (Fixture *f,
                                              "--subject", "Make Money Fast",
                                              "--body", "Your spam here",
                                              "--attach", "/dev/null",
+                                             "--cc", "us@example.com",
+                                             "--cc", "them@example.com",
+                                             "--bcc", "hidden@example.com",
+                                             "--bcc", "secret@example.com",
                                              "me@example.com",
+                                             "you@example.com",
                                              NULL);
   g_assert_no_error (error);
   g_assert_nonnull (f->xdg_email);
@@ -410,11 +415,25 @@ test_maximal (Fixture *f,
     {
       g_assert_true (g_variant_dict_lookup (dict, "addresses", "^a&s", &addresses));
       g_assert_cmpstr (addresses[0], ==, "me@example.com");
-      g_assert_cmpstr (addresses[1], ==, NULL);
+      g_assert_cmpstr (addresses[1], ==, "you@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
+      g_free (addresses);
+
+      g_assert_true (g_variant_dict_lookup (dict, "cc", "^a&s", &addresses));
+      g_assert_cmpstr (addresses[0], ==, "us@example.com");
+      g_assert_cmpstr (addresses[1], ==, "them@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
+      g_free (addresses);
+
+      g_assert_true (g_variant_dict_lookup (dict, "bcc", "^a&s", &addresses));
+      g_assert_cmpstr (addresses[0], ==, "hidden@example.com");
+      g_assert_cmpstr (addresses[1], ==, "secret@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
       g_free (addresses);
     }
   else
     {
+      /* all addresses except the first are ignored */
       g_assert_true (g_variant_dict_lookup (dict, "address", "&s", &address));
       g_assert_cmpstr (address, ==, "me@example.com");
     }


### PR DESCRIPTION
The addition of Email v3 support in 0c2b15c7 caused the automated tests to fail. This was not completely deterministic, because it depended on uninitialized stack contents; for me, it reliably failed on Debian 10 (and on Travis-CI) but passed on Debian testing/unstable.

The important fix here is "xdg-email: Cope gracefully with version being unavailable or wrong type", which could be cherry-picked if there are problems with the rest.

* CI: Install a newer version of Ninja for Ubuntu 16.04, too
    
    The latest version of Meson requires a newer version of Ninja than
    the one available in Ubuntu 16.04.

* Use Ubuntu 18.04 rather than 16.04 for CI

* build: Request C99, with GNU extensions
    
    Otherwise inline declarations like "for (int i = 0; ...)" are an error.

* xdg-email: Cope gracefully with version being unavailable or wrong type
    
    If we run xdg-email against an old version of xdg-desktop-portal,
    getting the version property will raise an error, leaving v NULL
    and version undefined (with warnings). Treat that as being version 0.

* xdg-email: make version a guint32, not guint
    
    Strictly speaking g_variant_get ("u", .) expects a guint32 *, not a
    guint *, although in any reasonable ABI those are the same.

* xdg-email: Fix compilation against older GLib

* tests: Fail tests on critical warnings

* test-email: Add minimal support for mock Email interface v3
    
    This asserts that we set the "address" parameter if the interface
    version is older than 3 or unspecified, or the "addresses" parameter
    otherwise. The new features of v3 (multiple addresses, cc and bcc)
    are not tested yet.

* test-email: Exercise the --cc and --bcc options