### PR TITLE
xdg-email: Accept mailto: URIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,15 @@
 # SOFTWARE.
 
 sudo: required
-dist: xenial
+dist: bionic
 language: c
 script:
   - ./tests/ci-install.sh
   - ci_parallel=2 ci_sudo=yes ./tests/ci-build.sh
 
 env:
-  # GLib 2.48
-  - ci_suite=xenial
+  # GLib 2.56
+  - ci_suite=bionic
   # GLib 2.40. Not building the debug variant because the compiler is too
   # old to support -fsanitize=address
   - ci_docker=ubuntu:trusty ci_distro=ubuntu ci_suite=trusty ci_variant=production

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
   license: 'LGPL-2.1+',
   default_options: [
     'buildtype=debugoptimized',
+    'c_std=gnu99',
     'warning_level=2',
   ],
   meson_version: '>= 0.46.0',

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -32,10 +32,11 @@
 #define PORTAL_BUS_NAME    "org.freedesktop.portal.Desktop"
 #define PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
 #define PORTAL_IFACE_NAME  "org.freedesktop.portal.Email"
+#define PORTAL_IFACE_NAME_OPENURI "org.freedesktop.portal.OpenURI"
 
 static char **addresses = NULL;
-static char **cc = NULL;
-static char **bcc = NULL;
+static char **opt_cc = NULL;
+static char **opt_bcc = NULL;
 static gboolean show_help = FALSE;
 static gboolean show_version = FALSE;
 
@@ -47,9 +48,9 @@ static char *attach = NULL;
 static GOptionEntry entries[] = {
   {"utf8", 0, 0, G_OPTION_ARG_NONE, &use_utf8,
    N_("Indicates that all command line options are in utf8"), NULL },
-  { "cc", 0, 0, G_OPTION_ARG_STRING_ARRAY, &cc,
+  { "cc", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_cc,
     N_("Specify a recipient to be copied on the e-mail"), N_("address")},
-  { "bcc", 0, 0, G_OPTION_ARG_STRING_ARRAY, &bcc,
+  { "bcc", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_bcc,
     N_("Specify a recipient to be blindly copied on the e-mail"), N_("address")},
   { "subject", 0, 0, G_OPTION_ARG_STRING, &subject,
     N_("Specify a subject for the e-mail"), N_("text")},
@@ -78,6 +79,11 @@ main (int argc, char *argv[])
   g_autoptr(GVariant) ret = NULL;
   g_autoptr(GVariant) v = NULL;
   guint32 version = 0;
+  g_autoptr(GPtrArray) to = NULL;
+  g_autoptr(GPtrArray) cc = NULL;
+  g_autoptr(GPtrArray) bcc = NULL;
+  gsize i;
+  const char *single_uri = NULL;
 
   context = g_option_context_new ("[ mailto-uri | address(es) ]");
 
@@ -101,13 +107,147 @@ main (int argc, char *argv[])
       return 0;
     }
 
-  if (show_help || addresses == NULL)
+  if (show_help || addresses == NULL || addresses[0] == NULL)
     {
       char *help = g_option_context_get_help (context, TRUE, NULL);
       g_print ("%s\n", help);
 
       g_free (help);
       return 0;
+    }
+
+  /* If there is only one argument and it is a mailto: URI, behave like
+   * xdg-open instead, allowing the full generality of RFC 6068 mailto:
+   * URLs */
+  if ((opt_cc == NULL || *opt_cc == NULL) &&
+      (opt_bcc == NULL || *opt_bcc == NULL) &&
+      subject == NULL && body == NULL && attach == NULL &&
+      addresses[1] == NULL &&
+      g_ascii_strncasecmp (addresses[0], "mailto:", strlen ("mailto:")) == 0)
+    {
+      single_uri = addresses[0];
+    }
+  else
+    {
+      to = g_ptr_array_new_full (g_strv_length (addresses), g_free);
+      cc = g_ptr_array_new_full (opt_cc == NULL ? 0 : g_strv_length (opt_cc), g_free);
+      bcc = g_ptr_array_new_full (opt_bcc == NULL ? 0 : g_strv_length (opt_bcc), g_free);
+
+      for (i = 0; opt_cc != NULL && opt_cc[i] != NULL; i++)
+        g_ptr_array_add (cc, g_strdup (opt_cc[i]));
+
+      for (i = 0; opt_bcc != NULL && opt_bcc[i] != NULL; i++)
+        g_ptr_array_add (bcc, g_strdup (opt_bcc[i]));
+
+      for (i = 0; addresses[i] != NULL; i++)
+        {
+          if (g_ascii_strncasecmp (addresses[i], "mailto:",
+                                   strlen ("mailto:")) == 0)
+            {
+              g_autofree gchar *rest = g_strdup (addresses[i] + strlen ("mailto:"));
+              char *token;
+              char *question_mark = strchr (rest, '?');
+              char *saveptr = NULL;
+
+              if (question_mark != NULL)
+                *question_mark = '\0';
+
+              /* The part before any '?' is a comma-separated list of URI-escaped
+               * email addresses, but may be empty */
+              if (rest[0] != '\0')
+                {
+                  for (token = strtok_r (rest, ",", &saveptr);
+                       token != NULL;
+                       token = strtok_r (NULL, ",", &saveptr))
+                    {
+                      g_autofree gchar *addr = g_uri_unescape_string (token, NULL);
+
+                      if (addr != NULL)
+                        g_ptr_array_add (to, g_steal_pointer (&addr));
+                      else
+                        g_warning ("Invalid URI-escaped email address: %s", token);
+                    }
+                }
+
+              if (question_mark == NULL)
+                continue;
+
+              /* The part after '?' (if any) is an &-separated list of header
+               * field/value pairs */
+              for (token = strtok_r (question_mark + 1, "&", &saveptr);
+                   token != NULL;
+                   token = strtok_r (NULL, "&", &saveptr))
+                {
+                  g_autofree gchar *value = NULL;
+                  char *equals = strchr (token, '=');
+                  const char *header;
+
+                  if (equals == NULL)
+                    {
+                      g_warning ("No '=' found in %s", token);
+                      continue;
+                    }
+
+                  *equals = '\0';
+                  header = token;
+                  value = g_uri_unescape_string (equals + 1, NULL);
+
+                  if (value == NULL)
+                    {
+                      g_warning ("Invalid URI-escaped value for '%s': %s",
+                                 header, value);
+                      continue;
+                    }
+
+                  if (g_ascii_strcasecmp (header, "to") == 0)
+                    {
+                      char *a, *saveptr2 = NULL;
+
+                      for (a = strtok_r (value, ",", &saveptr2);
+                           a != NULL;
+                           a = strtok_r (NULL, ",", &saveptr2))
+                        g_ptr_array_add (to, g_strdup (a));
+                    }
+                  else if (g_ascii_strcasecmp (header, "cc") == 0)
+                    {
+                      char *a, *saveptr2 = NULL;
+
+                      for (a = strtok_r (value, ",", &saveptr2);
+                           a != NULL;
+                           a = strtok_r (NULL, ",", &saveptr2))
+                        g_ptr_array_add (cc, g_strdup (a));
+                    }
+                  else if (g_ascii_strcasecmp (header, "bcc") == 0)
+                    {
+                      char *a, *saveptr2 = NULL;
+
+                      for (a = strtok_r (value, ",", &saveptr2);
+                           a != NULL;
+                           a = strtok_r (NULL, ",", &saveptr2))
+                        g_ptr_array_add (bcc, g_strdup (a));
+                    }
+                  else if (g_ascii_strcasecmp (header, "subject") == 0)
+                    {
+                      g_clear_pointer (&subject, g_free);
+                      subject = g_steal_pointer (&value);
+                    }
+                  else if (g_ascii_strcasecmp (header, "body") == 0)
+                    {
+                      g_clear_pointer (&body, g_free);
+                      body = g_steal_pointer (&value);
+                    }
+                  else
+                    {
+                      g_debug ("Ignoring unknown header field in mailto: URI: %s",
+                               header);
+                    }
+                }
+            }
+          else
+            {
+              g_ptr_array_add (to, g_strdup (addresses[i]));
+            }
+        }
     }
 
   connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, &error);
@@ -121,6 +261,37 @@ main (int argc, char *argv[])
 
       g_clear_pointer (&error, g_error_free);
       return 3;
+    }
+
+  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
+
+  if (single_uri != NULL)
+    {
+      ret = g_dbus_connection_call_sync (connection,
+                                         PORTAL_BUS_NAME,
+                                         PORTAL_OBJECT_PATH,
+                                         PORTAL_IFACE_NAME_OPENURI,
+                                         "OpenURI",
+                                         g_variant_new ("(ss@a{sv})",
+                                                        "", single_uri,
+                                                        g_variant_builder_end (&opt_builder)),
+                                         NULL,
+                                         G_DBUS_CALL_FLAGS_NONE,
+                                         -1,
+                                         NULL,
+                                         &error);
+
+      if (ret == NULL)
+        {
+          g_printerr ("Failed to call portal: %s\n", error->message);
+
+          g_object_unref (connection);
+          g_error_free (error);
+          return 4;
+        }
+
+      g_object_unref (connection);
+      return 0;
     }
 
   ret = g_dbus_connection_call_sync (connection,
@@ -145,29 +316,37 @@ main (int argc, char *argv[])
                    g_variant_get_type_string (v));
     }
 
-  g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
-
   if (version >= 3)
     {
       g_variant_builder_add (&opt_builder,
                              "{sv}",
-                             "addresses", g_variant_new_strv ((const char * const *)addresses, -1));
+                             "addresses",
+                             g_variant_new_strv ((const char * const *) to->pdata,
+                                                 to->len));
 
-      if (cc != NULL)
+      if (cc->len > 0)
         g_variant_builder_add (&opt_builder,
                                "{sv}",
-                               "cc", g_variant_new_strv ((const char * const *)cc, -1));
+                               "cc", g_variant_new_strv ((const char * const *) cc->pdata,
+                                                         cc->len));
 
-      if (bcc != NULL)
+      if (bcc->len > 0)
         g_variant_builder_add (&opt_builder,
                                "{sv}",
-                               "bcc", g_variant_new_strv ((const char * const *)bcc, -1));
+                               "bcc", g_variant_new_strv ((const char * const *) bcc->pdata,
+                                                          bcc->len));
     }
   else
     {
+      if (to->len == 0)
+        {
+          g_printerr ("xdg-email: No valid addresses found\n");
+          return 1;
+        }
+
       g_variant_builder_add (&opt_builder,
                              "{sv}",
-                             "address", g_variant_new_string (addresses[0]));
+                             "address", g_variant_new_string (g_ptr_array_index (to, 0)));
     }
 
   if (subject != NULL)

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -27,6 +27,8 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "backport-autoptr.h"
+
 #define PORTAL_BUS_NAME    "org.freedesktop.portal.Desktop"
 #define PORTAL_OBJECT_PATH "/org/freedesktop/portal/desktop"
 #define PORTAL_IFACE_NAME  "org.freedesktop.portal.Email"

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -75,7 +75,7 @@ main (int argc, char *argv[])
   GUnixFDList *fd_list = NULL;
   g_autoptr(GVariant) ret = NULL;
   g_autoptr(GVariant) v = NULL;
-  guint version;
+  guint version = 0;
 
   context = g_option_context_new ("[ mailto-uri | address(es) ]");
 
@@ -132,8 +132,16 @@ main (int argc, char *argv[])
                                      G_MAXINT,
                                      NULL,
                                      NULL);
-  g_variant_get (ret, "(v)", &v);
-  g_variant_get (v, "u", &version);
+  if (ret != NULL)
+    {
+      g_variant_get (ret, "(v)", &v);
+
+      if (g_variant_is_of_type (v, G_VARIANT_TYPE ("u")))
+        g_variant_get (v, "u", &version);
+      else
+        g_warning ("o.fd.portal.Email.version had unexpected type %s",
+                   g_variant_get_type_string (v));
+    }
 
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
 

--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -75,7 +75,7 @@ main (int argc, char *argv[])
   GUnixFDList *fd_list = NULL;
   g_autoptr(GVariant) ret = NULL;
   g_autoptr(GVariant) v = NULL;
-  guint version = 0;
+  guint32 version = 0;
 
   context = g_option_context_new ("[ mailto-uri | address(es) ]");
 

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -93,9 +93,14 @@ case "$ci_distro" in
         fi
 
         case "$ci_suite" in
-            (trusty)
+            (trusty|xenial)
                 wget https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
                 $sudo unzip ninja-linux.zip -d /usr/local/bin
+                ;;
+        esac
+
+        case "$ci_suite" in
+            (trusty)
                 $sudo apt-get -qq -y --no-install-recommends install \
                     python3.5
                 $sudo python3.5 /usr/bin/pip3 install meson

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,5 @@
 test_env = environment()
-test_env.set('G_DEBUG', 'gc-friendly')
+test_env.set('G_DEBUG', 'gc-friendly,fatal-criticals')
 test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
 test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
 test_env.set('GIO_USE_VFS', 'local')

--- a/tests/test-email.c
+++ b/tests/test-email.c
@@ -379,7 +379,12 @@ test_maximal (Fixture *f,
                                              "--subject", "Make Money Fast",
                                              "--body", "Your spam here",
                                              "--attach", "/dev/null",
+                                             "--cc", "us@example.com",
+                                             "--cc", "them@example.com",
+                                             "--bcc", "hidden@example.com",
+                                             "--bcc", "secret@example.com",
                                              "me@example.com",
+                                             "you@example.com",
                                              NULL);
   g_assert_no_error (error);
   g_assert_nonnull (f->xdg_email);
@@ -410,11 +415,25 @@ test_maximal (Fixture *f,
     {
       g_assert_true (g_variant_dict_lookup (dict, "addresses", "^a&s", &addresses));
       g_assert_cmpstr (addresses[0], ==, "me@example.com");
-      g_assert_cmpstr (addresses[1], ==, NULL);
+      g_assert_cmpstr (addresses[1], ==, "you@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
+      g_free (addresses);
+
+      g_assert_true (g_variant_dict_lookup (dict, "cc", "^a&s", &addresses));
+      g_assert_cmpstr (addresses[0], ==, "us@example.com");
+      g_assert_cmpstr (addresses[1], ==, "them@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
+      g_free (addresses);
+
+      g_assert_true (g_variant_dict_lookup (dict, "bcc", "^a&s", &addresses));
+      g_assert_cmpstr (addresses[0], ==, "hidden@example.com");
+      g_assert_cmpstr (addresses[1], ==, "secret@example.com");
+      g_assert_cmpstr (addresses[2], ==, NULL);
       g_free (addresses);
     }
   else
     {
+      /* all addresses except the first are ignored */
       g_assert_true (g_variant_dict_lookup (dict, "address", "&s", &address));
       g_assert_cmpstr (address, ==, "me@example.com");
     }


### PR DESCRIPTION
The reference xdg-email shell script documents that it supports mailto:
URIs, and it appears that at least Chromium and Jami (formerly GNU Ring)
genuinely make use of that feature.

If the only non-ignored argument is a mailto: URI, we pass it
directly to the OpenURI portal without further processing. This mode
can be used by applications wishing to do tricky things with headers
that we don't directly support.

Otherwise, we parse the mailto: URI and extract the header, subject
and addresses. Other headers are ignored.

The reference xdg-email script only accepts one mailto: URI, but
accepting more than one is actually easier than not, so we do that.

Resolves: https://github.com/flatpak/flatpak-xdg-utils/issues/19

---

Branch based on #31 to get the tests to pass. Only the last commit is new here.

One slightly weird thing in the current implementation is that with the stable (1.6.x) version of xdg-desktop-portal, calling OpenURI for a `mailto:` URI prompts to choose an app, whereas ComposeEmail goes directly to the composer app. This is fixed in the 1.7.x development branch.