### PR TITLE
flatpak-spawn: Fix exit status on seeing a weird wait-status

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -88,7 +88,7 @@ spawn_exited_cb (G_GNUC_UNUSED GDBusConnection *connection,
 
   if (child_pid == client_pid)
     {
-      int exit_code = 0;
+      int exit_code;
 
       if (WIFEXITED (exit_status))
         {
@@ -115,7 +115,7 @@ spawn_exited_cb (G_GNUC_UNUSED GDBusConnection *connection,
           /* EX_SOFTWARE "internal software error" from sysexits.h, for want of
            * a better code.
            */
-          exit_status = 70;
+          exit_code = 70;
         }
 
       g_debug ("child exit code %d: %d", client_pid, exit_code);

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -78,23 +78,23 @@ spawn_exited_cb (G_GNUC_UNUSED GDBusConnection *connection,
                  G_GNUC_UNUSED gpointer         user_data)
 {
   guint32 client_pid = 0;
-  guint32 exit_status = 0;
+  guint32 wait_status = 0;
 
   if (!g_variant_is_of_type (parameters, G_VARIANT_TYPE ("(uu)")))
     return;
 
-  g_variant_get (parameters, "(uu)", &client_pid, &exit_status);
-  g_debug ("child exited %d: %d", client_pid, exit_status);
+  g_variant_get (parameters, "(uu)", &client_pid, &wait_status);
+  g_debug ("child exited %d: %d", client_pid, wait_status);
 
   if (child_pid == client_pid)
     {
       int exit_code;
 
-      if (WIFEXITED (exit_status))
+      if (WIFEXITED (wait_status))
         {
-          exit_code = WEXITSTATUS (exit_status);
+          exit_code = WEXITSTATUS (wait_status);
         }
-      else if (WIFSIGNALED (exit_status))
+      else if (WIFSIGNALED (wait_status))
         {
           /* Smush the signal into an unsigned byte, as the shell does. This is
            * not quite right from the perspective of whatever ran flatpak-spawn
@@ -102,7 +102,7 @@ spawn_exited_cb (G_GNUC_UNUSED GDBusConnection *connection,
            *  alternative is to disconnect all signal() handlers then send this
            *  signal to ourselves and hope it kills us.
            */
-          exit_code = 128 + WTERMSIG (exit_status);
+          exit_code = 128 + WTERMSIG (wait_status);
         }
       else
         {
@@ -110,8 +110,8 @@ spawn_exited_cb (G_GNUC_UNUSED GDBusConnection *connection,
            * code specified neither WUNTRACED nor WIFSIGNALED, then exactly one
            * of WIFEXITED() or WIFSIGNALED() will be true.
            */
-          g_warning ("exit status %d is neither WIFEXITED() nor WIFSIGNALED()",
-                     exit_status);
+          g_warning ("wait status %d is neither WIFEXITED() nor WIFSIGNALED()",
+                     wait_status);
           /* EX_SOFTWARE "internal software error" from sysexits.h, for want of
            * a better code.
            */


### PR DESCRIPTION
* flatpak-spawn: Use exit code 70 for weird wait-statuses as intended
    
    The original implementation mistakenly reset exit_status instead of
    exit_code. This originally left exit_code undefined, with subsequent
    commit 50991f5f "Fix (bogus) uninitialized use warning" changing the
    undefined exit code to 0.
    
    Revert 50991f5f, because the warning turned out not to have
    been bogus, and should be silenced by this change.
    
    Fixes: 54c5800f "spawn: fix propagating exit code"

* flatpak-spawn: Clarify a variable name
    
    I usually find that code dealing with POSIX-style exit statuses is
    clearer if we distinguish between a "wait status" (what wait() or
    waitpid() gives us, referred to as "wstatus" in Linux wait(2))
    and an "exit status" (what we pass to exit(3), or equivalently, what
    we can extract from a wait status with the WEXITSTATUS macro).

The last commit can be dropped if the flatpak-xdg-utils maintainers don't think it improves clarity.