### PR TITLE
xdg-open: Avoid the use of O_PATH fds

### DIFF
--- a/src/xdg-open.c
+++ b/src/xdg-open.c
@@ -106,7 +106,7 @@ main (int argc, char *argv[])
       GUnixFDList *fd_list;
 
       path = g_file_get_path (file);
-      fd = open (path, O_PATH | O_CLOEXEC);
+      fd = open (path, O_RDONLY | O_CLOEXEC);
       if (fd == -1)
         {
           g_printerr ("Failed to open '%s': %s", path, g_strerror (errno));


### PR DESCRIPTION
As of xdg-desktop-portal 1.8.0, the writable checks become far more
strict, meaning that passing an O_PATH fd that the current application
has write access to without declaring that it should be writable will
result in the open failing. This drops O_PATH in favor of the new
standard fd support, and opens the descriptor as read-only to match
the GLib behavior.

Fixes flatpak/flatpak#3879.