### PR TITLE
Factor out and improve path_to_handle()

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -519,6 +519,7 @@ path_to_handle (GUnixFDList *fd_list,
   if (handle < 0)
     {
       g_prefix_error (error, "Failed to add fd to list for %s: ", path);
+      close (path_fd);
       return -1;
     }
 


### PR DESCRIPTION
Preparatory work for supporting https://github.com/flatpak/flatpak/pull/4018

---

* flatpak-spawn: Factor out path_to_handle()
    
    This will let us deal with arguments that are a single path, instead
    of a GStrv of paths.

* flatpak-spawn: Try to normalize exposed paths to be in ~/.var/app
    
    The Flatpak portal will reject paths that do not resolve to the same
    thing in the container and on the host system. For example,
    
        --sandbox-expose-path="$HOME/.config/my/file"
    
    will not work, even if
    
        --sandbox-expose-path="$HOME/.var/app/com.example.App/config/my/file"
    
    would.
    
    Existing apps like GNOME Web (Epiphany) get away with this because the
    files they are exposing are below $XDG_CONFIG_HOME, $XDG_DATA_HOME or
    $XDG_CACHE_HOME, which take values below ~/.var/app, but the same is
    not necessarily going to be true for apps like Steam that use --persist.