### PR TITLE
flatpak-spawn: Add the ability to set a custom path for /app or /usr

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -519,6 +519,7 @@ path_to_handle (GUnixFDList *fd_list,
   if (handle < 0)
     {
       g_prefix_error (error, "Failed to add fd to list for %s: ", path);
+      close (path_fd);
       return -1;
     }
 

--- a/tests/common.c
+++ b/tests/common.c
@@ -97,3 +97,17 @@ own_name_sync (GDBusConnection *conn,
   g_variant_get (variant, "(u)", &result);
   g_assert_cmpuint (result, ==, DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER);
 }
+
+/* A GAsyncReadyCallback that stores @res via a `GAsyncResult **`. */
+void
+store_result_cb (G_GNUC_UNUSED GObject *source,
+                 GAsyncResult *res,
+                 gpointer data)
+{
+  GAsyncResult **res_p = data;
+
+  g_assert_nonnull (res_p);
+  g_assert_null (*res_p);
+  g_assert_true (G_IS_ASYNC_RESULT (res));
+  *res_p = g_object_ref (res);
+}

--- a/tests/common.h
+++ b/tests/common.h
@@ -35,3 +35,9 @@ void setup_dbus_daemon (GSubprocess **dbus_daemon,
                         gchar       **dbus_address);
 void own_name_sync (GDBusConnection *conn,
                     const char *name);
+void store_result_cb (GObject *source, GAsyncResult *res, gpointer data);
+
+#ifndef g_assert_no_errno
+#define g_assert_no_errno(expr) \
+  g_assert_cmpstr ((expr) >= 0 ? NULL : g_strerror (errno), ==, NULL)
+#endif


### PR DESCRIPTION
Based on the refactoring from #38.

---

* #38 

* flatpak-spawn: Add the ability to set a custom path for /app or /usr
    
    This is a client-side for
    <https://github.com/flatpak/flatpak/pull/4018>.
    
    Steam's pressure-vessel tool does the equivalent of this to launch
    a parallel container with /usr supplied by the Steam Runtime, and an
    empty /app, although currently it has to use code derived from
    flatpak-spawn rather than using the runtime's copy of flatpak-spawn.

* test-spawn: Check contents of options dict more extensibly
    
    Instead of asserting that there is a hard-coded number of items in the
    dict, count how many items we have checked and then assert that there
    are no extra items left over at the end. This will make it easier to
    test more options that add more items.

* tests: Exercise flatpak-spawn --app-path and --usr-path