### PR TITLE
xdg-email: Send attachments using the correct option name and type

### DIFF
--- a/src/xdg-email.c
+++ b/src/xdg-email.c
@@ -385,7 +385,7 @@ main (int argc, char *argv[])
 
       g_variant_builder_add (&opt_builder,
                              "{sv}",
-                             "attachments", g_variant_new_parsed ("[0]"));
+                             "attachment_fds", g_variant_new_parsed ("@ah [0]"));
     }
 
   parameters = g_variant_new ("(s@a{sv})",


### PR DESCRIPTION
xdg-desktop-portal 0.9 switched from attachments as an array of URIs to
attachment_fds as an array of fds, but flatpak-xdg-utils 1.0.0 switched
from attachments as an array of URIs to attachments as an array of ints
(not fds!), resulting in failure to interoperate.

Fixes: f8ed903c "email: Pass attachments as fds"  
Resolves: #50
