### PR TITLE
flatpak-spawn: Fix memory leak when receiving NameOwnerChanged

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -284,7 +284,7 @@ name_owner_changed (G_GNUC_UNUSED GDBusConnection *connection,
                     G_GNUC_UNUSED gpointer         user_data)
 {
   const char *name, *from, *to;
-  g_variant_get (parameters, "(sss)", &name, &from, &to);
+  g_variant_get (parameters, "(&s&s&s)", &name, &from, &to);
 
   /* Check if the service dies, then we exit, because we can't track it anymore */
   if (strcmp (name, service_bus_name) == 0 &&


### PR DESCRIPTION
Spotted while adding test coverage to Steam's `steam-runtime-launch-client` (formerly `pressure-vessel-launch`), which is derived from `flatpak-spawn`.