### PR TITLE
Show permission hint for flatpk-spawn --host

### DIFF
--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -1297,7 +1297,7 @@ retry:
 
         g_dbus_error_strip_remote_error (error);
         g_printerr ("Portal call failed: %s\n", error->message);
-        if (opt_host) {
+        if (opt_host && g_strcmp0 (error->message, "org.freedesktop.DBus.Error.ServiceUnknown") == 0) {
           g_printerr ("Hint: --host only works when the Flatpak is allowed to talk to org.freedesktop.Flatpak\n");
         }
         return 1;

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -1297,6 +1297,9 @@ retry:
 
         g_dbus_error_strip_remote_error (error);
         g_printerr ("Portal call failed: %s\n", error->message);
+        if (opt_host) {
+          g_printerr ("Hint: --host only works when the Flatpak is allowed to talk to org.freedesktop.Flatpak\n");
+        }
         return 1;
       }
 

--- a/src/flatpak-spawn.c
+++ b/src/flatpak-spawn.c
@@ -1297,7 +1297,7 @@ retry:
 
         g_dbus_error_strip_remote_error (error);
         g_printerr ("Portal call failed: %s\n", error->message);
-        if (opt_host && g_strcmp0 (error->message, "org.freedesktop.DBus.Error.ServiceUnknown") == 0) {
+        if (opt_host && g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN)) {
           g_printerr ("Hint: --host only works when the Flatpak is allowed to talk to org.freedesktop.Flatpak\n");
         }
         return 1;


### PR DESCRIPTION
If `flatpak-spwan --host` fails, it now shows a message that thee Flatpak needs to permission to talk to org.freedesktop.Flatpak.  This would make it more clear for people who are new to Flatpak and have read, that you can execute host commands with `flatpak-spawn`.