### PR TITLE
ci (workflows): bump actions version, fix node deprecation warning

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -10,6 +10,6 @@ jobs:
 
     steps:
       - name: Block Autosquash Commits
-        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        uses: xt0rted/block-autosquash-commits-action@v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y dbus libglib2.0-dev meson
     - name: Check out
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Configure
       run: meson -Db_sanitize=address,undefined _build
     - name: Build
@@ -24,7 +24,7 @@ jobs:
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: logs


### PR DESCRIPTION
## Changes

- Bump `xt0rted/block-autosquash-commits-action` to `v2.2.0`.
- Bump `actions/checkout` from `v1` to `v3` (Node 16).
- Bump `actions/upload-artifacts` from `v1` to `v3` (Node 16).

This PR fixes the Node 12 deprecation warning that will be displayed in action runs by bumping the actions to Node 16.