### PR TITLE
Github workflow: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         ASAN_OPTIONS: detect_leaks=0 # Right now we're not fully clean, but this gets us use-after-free etc
     - name: Upload test logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
         name: logs


### PR DESCRIPTION
Version 3 of the action was deprecated on 2025-01-30, see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/