### PR TITLE
Add support for new device flags

### DIFF
--- a/src/flatpak-portal.h
+++ b/src/flatpak-portal.h
@@ -45,6 +45,11 @@ typedef enum {
   FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU = 1 << 2,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS = 1 << 3,
   FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y = 1 << 4,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_INPUT = 1 << 5,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_USB = 1 << 6,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_KVM = 1 << 7,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SHM = 1 << 8,
+  FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DEVICES = 1 << 9,
   FLATPAK_SPAWN_SANDBOX_FLAGS_NONE = 0
 } FlatpakSpawnSandboxFlags;
 
@@ -72,6 +77,11 @@ typedef enum {
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SOUND | \
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_GPU | \
                                          FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_DBUS | \
-                                         FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y)
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_ALLOW_A11Y | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_INPUT | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_USB | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_KVM | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_SHM | \
+                                         FLATPAK_SPAWN_SANDBOX_FLAGS_SHARE_DEVICES)
 
 #endif /* __FLATPAK_PORTAL_H__ */


### PR DESCRIPTION
This PR adds support for the new device flags added in flatpak/flatpak#6123.

I also added a new `--sandbox-flag-try` option that just don't use the flag instead of exiting when the portal version is too old. 